### PR TITLE
Formula: add xerces to list of plugins with dependencies

### DIFF
--- a/Formula/elektra.rb
+++ b/Formula/elektra.rb
@@ -20,6 +20,7 @@ class Elektra < Formula
     "dbus"        => [Dependency.new("dbus", *opt)],
     "gitresolver" => [Dependency.new("libgit2", *opt)],
     "tcl"         => [Dependency.new("boost", *opt)],
+    "xerces"      => [Dependency.new("xerces-c", *opt)],
     "yajl"        => [Dependency.new("yajl", *opt)],
     "yamlcpp"     => [Dependency.new("yaml-cpp", *opt)],
   }


### PR DESCRIPTION
This PR adds xerces to the list of plugins with dependencies which fixes #3.

Commands to check the result:

1. Pull latest master
2. Uninstall elektra if installed
3. `brew install xerces-c`
4. In the Formula directory run `brew install --verbose --build-from-source ./elektra.rb --with-dep-plugins`
5. `kdb list` it should list the xerces plugin

